### PR TITLE
Revert "Fix not publishing entries if a probing interface is removed."

### DIFF
--- a/avahi-core/announce.c
+++ b/avahi-core/announce.c
@@ -44,12 +44,6 @@ static void remove_announcer(AvahiServer *s, AvahiAnnouncer *a) {
     AVAHI_LLIST_REMOVE(AvahiAnnouncer, by_interface, a->interface->announcers, a);
     AVAHI_LLIST_REMOVE(AvahiAnnouncer, by_entry, a->entry->announcers, a);
 
-    if (a->state == AVAHI_PROBING && a->entry->group) {
-	assert(a->entry->group->n_probing);
-	a->entry->group->n_probing--;
-	avahi_s_entry_group_check_probed(a->entry->group, 1);
-    }
-
     avahi_free(a);
 }
 


### PR DESCRIPTION
This reverts commit 57f740f0f7f4b46bd72139064beb7192ebd9431a.