### PR TITLE
Add Avahi server SHUTDOWN state

### DIFF
--- a/avahi-common/defs.h
+++ b/avahi-common/defs.h
@@ -223,7 +223,8 @@ typedef enum {
     AVAHI_SERVER_REGISTERING,      /**< Host RRs are being registered */
     AVAHI_SERVER_RUNNING,          /**< All host RRs have been established */
     AVAHI_SERVER_COLLISION,        /**< There is a collision with a host RR. All host RRs have been withdrawn, the user should set a new host name via avahi_server_set_host_name() */
-    AVAHI_SERVER_FAILURE           /**< Some fatal failure happened, the server is unable to proceed */
+    AVAHI_SERVER_FAILURE,          /**< Some fatal failure happened, the server is unable to proceed */
+    AVAHI_SERVER_SHUTDOWN          /**< Server is in process of shutting down */
 } AvahiServerState;
 
 /** States of an entry group object */

--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -1506,6 +1506,7 @@ AvahiServer *avahi_server_new(const AvahiPoll *poll_api, const AvahiServerConfig
 void avahi_server_free(AvahiServer* s) {
     assert(s);
 
+    server_set_state(s, AVAHI_SERVER_SHUTDOWN);
     /* Remove all browsers */
 
     while (s->dns_server_browsers)

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -1303,7 +1303,6 @@ finish:
 #endif
 
     if (avahi_server) {
-        server_set_state(avahi_server, AVAHI_SERVER_SHUTDOWN);
         avahi_server_free(avahi_server);
         avahi_server = NULL;
     }

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -414,7 +414,12 @@ static void server_callback(AvahiServer *s, AvahiServerState state, void *userda
             break;
 
         case AVAHI_SERVER_INVALID:
+        case AVAHI_SERVER_SHUTDOWN:
             break;
+
+        default:
+            avahi_log_error("%d: unknown state", state);
+            abort();
 
     }
 }
@@ -1298,6 +1303,7 @@ finish:
 #endif
 
     if (avahi_server) {
+        server_set_state(avahi_server, AVAHI_SERVER_SHUTDOWN);
         avahi_server_free(avahi_server);
         avahi_server = NULL;
     }


### PR DESCRIPTION
Set avahi server state to SHUTDOWN when stopping the server. By placing the avahi server in a non-running state we ensure that the callback for avahi server state changes (server_callback() in avahi-daemon/main.c) doesn't cause us to attempt to restart queries after freeing our global server information.